### PR TITLE
Update tests and code to parse correctly files ending with the subtitles text and not \n characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@
 */Entity/*~
 /.project
 /.idea
+
+# PHPUnit test logs
+/logs/

--- a/Providers/SubRipSubtitles.php
+++ b/Providers/SubRipSubtitles.php
@@ -17,7 +17,9 @@ class SubRipSubtitles extends Subtitles
         $contents = str_replace("\r", "", self::removeBom(file_get_contents($filename)));
 
         return preg_match(
-            "/^([0-9]+[[:space:]]*\n[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} --> [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}[[:space:]]*\n(.+\n)+\n)+/mU",
+            "/^([0-9]+[[:space:]]*\n" .
+            "[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} --> [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}[[:space:]]*\n" .
+            "(.+\n\n|.+\Z))+/mU",
             $contents,
             $matches
         );
@@ -38,7 +40,9 @@ class SubRipSubtitles extends Subtitles
         $contents = str_replace("\r", "", self::forceUtf8(file_get_contents($filename)));
 
         preg_match_all(
-            "/^([0-9]+)[[:space:]]*\n([0-9]{2}):([0-9]{2}):([0-9]{2}),([0-9]{3}) --> ([0-9]{2}):([0-9]{2}):([0-9]{2}),([0-9]{3})[[:space:]]*\n((.+\n)+)$/mU",
+            "/^([0-9]+)[[:space:]]*\n" .
+            "([0-9]{2}):([0-9]{2}):([0-9]{2}),([0-9]{3}) --> ([0-9]{2}):([0-9]{2}):([0-9]{2}),([0-9]{3})[[:space:]]*\n" .
+            "(.+\n\n|.+\Z)/smU",
             $contents,
             $matches,
             PREG_SET_ORDER

--- a/Providers/TxtSubtitles.php
+++ b/Providers/TxtSubtitles.php
@@ -17,7 +17,8 @@ class TxtSubtitles extends Subtitles
         $contents = str_replace("\r", "", self::removeBom(file_get_contents($filename)));
 
         return preg_match(
-            "/([0-9]+\)[[:space:]]*[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2}.*\n(.+\n)+\n)+/mU",
+            "/([0-9]+\)[[:space:]]*[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2}.*\n" .
+            "(.+\n\n|.+\Z))+/mU",
             $contents
         );
     }
@@ -37,7 +38,8 @@ class TxtSubtitles extends Subtitles
         $contents = str_replace("\r", "", self::forceUtf8(file_get_contents($filename)));
 
         preg_match_all(
-            "/([0-9]+\)[[:space:]]*([0-9]{2}):([0-9]{2}):([0-9]{2}):([0-9]{2})[[:space:]]+([0-9]{2}):([0-9]{2}):([0-9]{2}):([0-9]{2}).*\n((.+\n)+)\n)+/mU",
+            "/([0-9]+\)[[:space:]]*([0-9]{2}):([0-9]{2}):([0-9]{2}):([0-9]{2})[[:space:]]+([0-9]{2}):([0-9]{2}):([0-9]{2}):([0-9]{2}).*\n" .
+            "(.+\n\n|.+\Z))+/smU",
             $contents,
             $matches,
             PREG_SET_ORDER

--- a/Providers/WebVttSubtitles.php
+++ b/Providers/WebVttSubtitles.php
@@ -34,7 +34,9 @@ class WebVttSubtitles extends Subtitles
         $contents = str_replace("\r", "", self::forceUtf8(file_get_contents($filename)));
 
         preg_match_all(
-            "/([0-9]+)[[:space:]]*\n([0-9]{2}):([0-9]{2}):([0-9]{2})\.([0-9]{3}) --> ([0-9]{2}):([0-9]{2}):([0-9]{2})\.([0-9]{3})[[:space:]]*\n(([^\n]+\n)+)\n/mU",
+            "/([0-9]+)[[:space:]]*\n" .
+            "([0-9]{2}):([0-9]{2}):([0-9]{2})\.([0-9]{3}) --> ([0-9]{2}):([0-9]{2}):([0-9]{2})\.([0-9]{3})[[:space:]]*\n" .
+            "(.+\n\n|.+\Z)/smU",
             $contents,
             $matches,
             PREG_SET_ORDER

--- a/Tests/SubConverterTest.php
+++ b/Tests/SubConverterTest.php
@@ -42,8 +42,10 @@ class SubConverterTest extends WebTestCase
                 error_log($outputFilePath);
                 $converter->convert($file, $outputFilePath, $format);
 
-                $outputFileContent = file_get_contents($outputFilePath);
-                $originalFileContent = file_get_contents($originalFilename);
+                // The conversion of the files produces \n\n in the end
+                // We trim that to be able to check with original files correctly
+                $outputFileContent = trim(file_get_contents($outputFilePath));
+                $originalFileContent = trim(file_get_contents($originalFilename));
 
                 $this->assertEquals(
                     $originalFileContent,

--- a/Tests/resources/lorem_subtitle.srt
+++ b/Tests/resources/lorem_subtitle.srt
@@ -30,4 +30,3 @@ Quas hoc libro exposui arbitratu meo;
 00:02:14,840 --> 00:02:18,520
 quasi enim ipsos induxi loquentes,
 ne 'inquam' et 'inquit'.
-

--- a/Tests/resources/lorem_subtitle.txt
+++ b/Tests/resources/lorem_subtitle.txt
@@ -23,4 +23,3 @@ Quas hoc libro exposui arbitratu meo;
 7) 00:02:14:21 00:02:18:13
 quasi enim ipsos induxi loquentes,
 ne 'inquam' et 'inquit'.
-

--- a/Tests/resources/lorem_subtitle.webvtt
+++ b/Tests/resources/lorem_subtitle.webvtt
@@ -32,4 +32,3 @@ Quas hoc libro exposui arbitratu meo;
 00:02:14.840 --> 00:02:18.520
 quasi enim ipsos induxi loquentes,
 ne 'inquam' et 'inquit'.
-


### PR DESCRIPTION
I have updated the regexp to handle correctly .srt files in [IN:50046].
Here I've updated the corresponding regexp for .srt files, .vtt and .txt. I have also updated the corresponding tests and datas to reflect the change.